### PR TITLE
feat: VW options to codegen

### DIFF
--- a/test/runtest_coverage.py
+++ b/test/runtest_coverage.py
@@ -99,7 +99,7 @@ def prettyprint(config, filter_out_general=True):
         # general are the VW generic options
         if filter_out_general and name == "general":
             continue
-        # temp fix:
+        # temp fix: cb_adf gets added twice
         if name == "cb_adf":
             config_group.pop()
         for (group_name, options) in config_group:

--- a/test/runtest_coverage.py
+++ b/test/runtest_coverage.py
@@ -23,6 +23,101 @@ def to_json():
         f.write(json.dumps(config, indent=2, default=lambda x: x.__dict__))
 
 
+def print_option_group(desc, options):
+    if options:
+        print(desc)
+        for l in options:
+            print("\t\t// "+str(l._seq_id)+". "+l.help_str)
+            if l.default_value_supplied:
+                if l._type == "str":
+                    print("\t\t"+l._type+" " +l.name+" = \""+str(l.default_value)+"\";")
+                else:
+                    print("\t\t"+l._type+" " +l.name+" = "+str(l.default_value)+";")
+            else:
+                print("\t\t"+l._type+" " +l.name+";")
+        print()
+
+
+# dummy codegen
+# prints constructor for option group
+def necessary_to_constructor(name, options):
+    if len(options) == 0:
+        print("\t"+name + "() {}")
+    elif len(options) == 1:
+        if options[0]._type == "bool":
+            print("\t"+name + "() {}")
+        else:
+            print("\t"+name + "("+options[0]._type+" "+options[0].name+") {}")
+    elif len(options) == 2:
+        if "cb_explore_adf_" in name:
+            if "bool" == options[1]._type:
+                print("\t"+name + "() {}")
+            else:
+                print("\t"+name + "("+options[1]._type+" "+options[1].name+") {}")
+        else:
+            raise("not possible")
+    else:
+        raise("not possible")
+    print()
+
+
+def print_dummy_contract():
+    print("\t// fn to be used for add_parse_and_check_necessary of")
+    print("\t// config_backed_options (which would implement options_i)")
+    print("\t// this method is part of config_i interface")
+    print("\tbool process_option_group(option_group_definition ogd);")
+    print()
+
+
+def print_group(name, group_name, group_id, options):
+    print("// "+ str(group_id) + ". " + group_name)
+    print("// total options: " + str(len(options)))
+    print("pseudoclass " + name + "_config : config_i {")
+
+    necessary = list(filter(lambda x: x.necessary, options)) 
+    keep = list(filter(lambda x: x.keep, options)) 
+    bools = list(filter(lambda x: x._type == "bool" and x.keep == False, options)) 
+    default = list(filter(lambda x: x.default_value_supplied and x._type != "bool", options)) 
+    default = list(filter(lambda x: not x.keep and not x.necessary, default)) 
+    rest = list(filter(lambda x: not x.default_value_supplied and x._type != "bool", options)) 
+    rest = list(filter(lambda x: not x.keep and not x.necessary, rest)) 
+        
+    print_option_group("\tNECESSARY (turn on reduction):", necessary)
+    necessary_to_constructor(name+"_config", necessary)
+    print_dummy_contract()
+    print_option_group("\tKEEP (persisted in the model):", keep)
+    print_option_group("\tOTHER FLAGS (bools & !keep):", bools)
+    print_option_group("\tHAS_DEFAULT:", default)
+    print_option_group("\tNO_DEFAULT:", rest)
+
+    print("};\n")
+
+
+def prettyprint(config, filter_out_general=True):
+    group_id = 1
+    for name, config_group in config.items():
+        # general are the VW generic options
+        if filter_out_general and name == "general":
+            continue
+        # temp fix:
+        if name == "cb_adf":
+            config_group.pop()
+        for (group_name, options) in config_group:
+            num_id = 1
+            for option in options:
+                option._type = str(type(option._default_value).__name__)
+                option._seq_id = num_id
+                num_id += 1
+            print_group(name, group_name, group_id, options)
+            group_id += 1
+
+
+vw = pyvw.vw(arg_str="--cb_explore_adf")
+prettyprint(vw.get_config())
+
+# prettyprint(get_all_options(), False)
+exit()
+
 def get_config_of_vw_cmd(test):
     vw = pyvw.vw(arg_str=test["vw_command"])
     config = vw.get_config()


### PR DESCRIPTION
```
// 1. Contextual Bandit with Action Dependent Features
// total options: 5
pseudoclass cb_adf_config : config_i {
	NECESSARY (turn on reduction):
		// 1. Do Contextual Bandit learning with multiline action dependent features.
		bool cb_adf = False;

	cb_adf_config() {}

	// fn to be used for add_parse_and_check_necessary of
	// config_backed_options (which would implement options_i)
	// this method is part of config_i interface
	bool process_option_group(option_group_definition ogd);

	KEEP (persisted in the model):
		// 1. Do Contextual Bandit learning with multiline action dependent features.
		bool cb_adf = False;
		// 2. Return actions sorted by score order
		bool rank_all = False;
		// 4. Clipping probability in importance weight. Default: 0.f (no clipping).
		float clip_p = 0.0;
		// 5. contextual bandit method to use in {ips, dm, dr, mtr, sm}. Default: mtr
		str cb_type;

	OTHER FLAGS (bools & !keep):
		// 3. Do not do a prediction when training
		bool no_predict = False;

};

// 2. Contextual Bandit Exploration with ADF (greedy)
// total options: 3
pseudoclass cb_explore_adf_greedy_config : config_i {
	cb_explore_adf_greedy_config() {}

	// fn to be used for add_parse_and_check_necessary of
	// config_backed_options (which would implement options_i)
	// this method is part of config_i interface
	bool process_option_group(option_group_definition ogd);

	KEEP (persisted in the model):
		// 1. Online explore-exploit for a contextual bandit problem with multiline action dependent features
		bool cb_explore_adf = False;
		// 2. epsilon-greedy exploration
		float epsilon;
		// 3. Only explore the first action in a tie-breaking event
		bool first_only = False;

};

// 3. Cost Sensitive One Against All with Label Dependent Features
// total options: 4
pseudoclass csoaa_ldf_config : config_i {
	NECESSARY (turn on reduction):
		// 1. Use one-against-all multiclass learning with label dependent features.
		str csoaa_ldf;

	csoaa_ldf_config(str csoaa_ldf) {}

	// fn to be used for add_parse_and_check_necessary of
	// config_backed_options (which would implement options_i)
	// this method is part of config_i interface
	bool process_option_group(option_group_definition ogd);

	KEEP (persisted in the model):
		// 1. Use one-against-all multiclass learning with label dependent features.
		str csoaa_ldf;
		// 3. Return actions sorted by score order
		bool csoaa_rank = False;
		// 4. predict probabilites of all classes
		bool probabilities = False;

	NO_DEFAULT:
		// 2. Override singleline or multiline from csoaa_ldf or wap_ldf, eg if stored in file
		str ldf_override;

};

// 4. Gradient Descent options
// total options: 8
pseudoclass gd_config : config_i {
	gd_config() {}

	// fn to be used for add_parse_and_check_necessary of
	// config_backed_options (which would implement options_i)
	// this method is part of config_i interface
	bool process_option_group(option_group_definition ogd);

	OTHER FLAGS (bools & !keep):
		// 1. use regular stochastic gradient descent update.
		bool sgd = False;
		// 2. use adaptive, individual learning rates.
		bool adaptive = False;
		// 3. use adaptive learning rates with x^2 instead of g^2x^2
		bool adax = False;
		// 4. use safe/importance aware updates.
		bool invariant = False;
		// 5. use per feature normalized updates
		bool normalized = False;

	HAS_DEFAULT:
		// 6. use per feature normalized updates
		float sparse_l2 = 0.0;
		// 7. use per feature normalized updates
		float l1_state = 0.0;
		// 8. use per feature normalized updates
		float l2_state = 1.0;

};

// 5. scorer options
// total options: 1
pseudoclass scorer_config : config_i {
	scorer_config() {}

	// fn to be used for add_parse_and_check_necessary of
	// config_backed_options (which would implement options_i)
	// this method is part of config_i interface
	bool process_option_group(option_group_definition ogd);

	KEEP (persisted in the model):
		// 1. Specify the link function: identity, logistic, glf1 or poisson
		str link = "identity";

};


```